### PR TITLE
feat_Adminpanel-remove-from-normal-users closes #176

### DIFF
--- a/flask_app/templates/layout.html
+++ b/flask_app/templates/layout.html
@@ -39,7 +39,7 @@
                         <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
                         Logg ut</a>
                     </li>
-                    {% if current_user.is_admin %}
+                    {% if current_user.has_role('admin') %}
                     <li><a href="{{ url_for('admin') }}">
                         <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
                         {{ current_user.email }}</a>


### PR DESCRIPTION
Replaces the link to admin panel with a link to logout for non-admins.
