### PR TITLE
add delete_preview_task and reference it from files.py

### DIFF
--- a/flask_app/files.py
+++ b/flask_app/files.py
@@ -159,8 +159,7 @@ def delete_world_file(file_ref):
 
 
 def delete_world_preview(file_ref):
+    from tasks import delete_preview_task
     dir_path = safe_join_all(app.root_path, app.config['PREVIEW_STORAGE_PATH'], file_ref)
-    try:
-        shutil.rmtree(dir_path)
-    except OSError:
-        pass
+    result = delete_preview_task.delay(dir_path)
+    return result

--- a/flask_app/tasks.py
+++ b/flask_app/tasks.py
@@ -1,6 +1,7 @@
 from celery import Celery, current_app
 from celery.signals import after_task_publish
-import subprocess
+import subprocess, shutil
+
 
 app = Celery('tasks', broker='amqp://guest@master//')
 app.conf.update(
@@ -20,3 +21,9 @@ def generate_preview_task(self, config_path):
     subprocess.call(["overviewer.py", "--config=%s" % config_path])
     return "Preview complete."
 
+@app.task(name='tasks.delete_preview_task')
+def delete_preview_task(dir_path):
+    try:
+        shutil.rmtree(dir_path)
+    except OSError:
+        pass


### PR DESCRIPTION
What it says on the tin: deletion of previews is now handled by a celery task, so that pushing buttons remains responsive. Currently in same queue as generation of previews. Closes #222 
