### PR TITLE
Added workaround for logging because Salt overrides StreamHandler

### DIFF
--- a/flask_app/tasks.py
+++ b/flask_app/tasks.py
@@ -6,7 +6,12 @@ from flask_app import app
 import subprocess
 import shutil
 
+# Need to import and setup logger, otherwise Salt overrides it
+import sys
+import logging
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format="%(message)s")
 import salt.client
+
 
 celery = Celery('tasks', broker=app.config['CELERY_BROKER_URL'])
 celery.conf.update(app.config)

--- a/flask_app/tasks.py
+++ b/flask_app/tasks.py
@@ -7,6 +7,7 @@ import subprocess
 import shutil
 
 # Need to import and setup logger, otherwise Salt overrides it
+# See http://stackoverflow.com/questions/28041539/importing-salt-causes-flask-to-output-nothing-in-the-terminal
 import sys
 import logging
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format="%(message)s")


### PR DESCRIPTION
Importing Salt in tasks.py overrides the loghandler which is annoying.
This is an workaround.

http://stackoverflow.com/questions/28041539/importing-salt-causes-flask-to-output-nothing-in-the-terminal
